### PR TITLE
Consistent messages for object locking

### DIFF
--- a/includes/form_handlers.inc
+++ b/includes/form_handlers.inc
@@ -98,13 +98,7 @@ function islandora_object_lock_acquire_during_alter(&$form, &$form_state, Abstra
     // Object is locked...
     if (islandora_object_lock_user_has_lock($object)) {
       // ... and you have it! Jolly good!
-      drupal_set_message(t('You have the lock on this object, which you can <a href="@release_url">release</a>.', array(
-        '@release_url' => url("islandora/object/{$object->id}/manage/datastreams/locking/unlock", array(
-          'query' => array(
-            'destination' => $allow_acquisition ? "islandora/object/{$object->id}/manage/datastreams" : "islandora/object/{$object->id}/$path_suffix",
-          ),
-        )),
-      )), 'status', FALSE);
+      drupal_set_message(islandora_object_lock_get_locked_message($object), 'status', FALSE);
     }
     else {
       // ... but somebody else has it ...

--- a/includes/form_handlers.inc
+++ b/includes/form_handlers.inc
@@ -11,6 +11,8 @@
  * message output.
  */
 function islandora_object_lock_check_lock_validation_handler(&$form, &$form_state) {
+  form_load_include($form_state, 'inc', 'islandora_object_lock', 'includes/utilities');
+
   $info = $form_state['islandora_object_lock_info'];
   $object = islandora_object_load($info['pid']);
 
@@ -24,16 +26,7 @@ function islandora_object_lock_check_lock_validation_handler(&$form, &$form_stat
 
   if (!$owned) {
     if ($locked) {
-      $message = t('This object has been locked by another user.');
-      if (islandora_object_lock_request_unlock_access()) {
-        $message .= ' ' . t('You can request that they <a href="@release_url">release</a> the lock.', array(
-          '@release_url' => url("islandora/object/{$object->id}/request_unlock", array(
-            'query' => array(
-              'destination' => $manage_page,
-            ),
-          )),
-        ));
-      }
+      $message = islandora_object_lock_get_locked_message($object);
     }
     elseif ($path_suffix !== NULL && $allow_acquisition) {
       $message = t('Your lock has expired due to inactivity. To re-lock this object, please <a href="@edit_url">try again</a>. Any changes since your last save will be lost.', array(
@@ -116,17 +109,9 @@ function islandora_object_lock_acquire_during_alter(&$form, &$form_state, Abstra
     else {
       // ... but somebody else has it ...
       $redirect_url = is_null($redirect) ? "islandora/object/$object->id/manage" : $redirect;
-      $message = t('This object has been locked by another user.');
-      if (islandora_object_lock_request_unlock_access()) {
-        // ... but you can ask them to release it.
-        $message .= ' ' . t('You can request that they <a href="@release_url">release</a> the lock.', array(
-          '@release_url' => url("islandora/object/{$object->id}/request_unlock", array(
-            'query' => array(
-              'destination' => $redirect_url,
-            ),
-          )),
-        ));
-      }
+
+      $message = islandora_object_lock_get_locked_message($object);
+
       drupal_set_message(filter_xss($message), 'error');
       drupal_goto($redirect_url);
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -8,19 +8,39 @@
 /**
  * Alert user to the current object being locked.
  *
- * @global user
- *
  * @param AbstractObject $object
  *   The object that is locked.
  */
 function islandora_object_lock_handle_possible_lock_notice(AbstractObject $object) {
+  // Notify user that object is locked
+  if (islandora_object_lock_is_locked($object)) {
+    drupal_set_message(islandora_object_lock_get_locked_message($object), 'warning');
+  }
+}
+
+/**
+ * Get an appropriate message to display to the user about a locked object.
+ *
+ * @global user
+ *
+ * @param AbstractObject $object
+ *   The object that is locked.
+ *
+ * @return string
+ *   The message to display to the user.
+ */
+function islandora_object_lock_get_locked_message(AbstractObject $object) {
   global $user;
 
-  // Notify user that object is locked and they cannot manage it.
-  if (islandora_object_lock_is_locked($object) &&
-      $user->name != islandora_object_lock_get_lock_username($object) &&
-      islandora_object_lock_request_unlock_access()) {
+  if ($user->name == islandora_object_lock_get_lock_username($object)) {
 
+    return t("This object is <strong>locked by you</strong>, others cannot make changes to it. You may <strong><a href=\"!unlock_url\">remove the lock from this object</a></strong>.",
+      array(
+        '!unlock_url' => url("islandora/object/{$object->id}/manage/datastreams/locking/unlock"),
+      )
+    );
+
+  } else {
     $locked_by = user_load_by_name(islandora_object_lock_get_lock_username($object));
     if (module_exists('realname')) {
       $name = realname_load($locked_by);
@@ -31,29 +51,22 @@ function islandora_object_lock_handle_possible_lock_notice(AbstractObject $objec
       $name = $locked_by->name;
     }
 
-    drupal_set_message(
-      t("This object is <strong>locked by <a href=\"!user_url\">@user_name</a></strong>, so it cannot be managed. You may <strong><a href=\"!request_unlock_url\">request that they unlock the object</a></strong>.",
-        array(
-          '!user_url' => url("user/{$locked_by->uid}"),
-          '@user_name' => $name,
-          '!request_unlock_url' => url("islandora/object/{$object->id}/request_unlock"),
-        )
-      ),
-      'warning'
+    $message = t("This object is <strong>locked by <a href=\"!user_url\">@user_name</a></strong>, so it cannot be managed.",
+      array(
+        '!user_url' => url("user/{$locked_by->uid}"),
+        '@user_name' => $name,
+      )
     );
 
-  // Notify user that they own the lock and can remove it.
-  } else if (islandora_object_lock_is_locked($object) &&
-      $user->name == islandora_object_lock_get_lock_username($object)) {
+    if (islandora_object_lock_request_unlock_access()) {
+      $message .= ' ' . t("You may <strong><a href=\"!request_unlock_url\">request that they unlock the object</a></strong>.",
+          array(
+            '!request_unlock_url' => url("islandora/object/{$object->id}/request_unlock"),
+          )
+        );
+    }
 
-    drupal_set_message(
-      t("This object is <strong>locked by you</strong>, others cannot make changes to it. You may <strong><a href=\"!unlock_url\">remove the lock from this object</a></strong>.",
-        array(
-          '!unlock_url' => url("islandora/object/{$object->id}/manage/datastreams/locking/unlock"),
-        )
-      ),
-      'warning'
-    );
+    return $message;
   }
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -24,6 +24,9 @@ function islandora_object_lock_handle_possible_lock_notice(AbstractObject $objec
     $locked_by = user_load_by_name(islandora_object_lock_get_lock_username($object));
     if (module_exists('realname')) {
       $name = realname_load($locked_by);
+      if (empty($name)) {
+        $name = $locked_by->name;
+      }
     } else {
       $name = $locked_by->name;
     }
@@ -32,7 +35,7 @@ function islandora_object_lock_handle_possible_lock_notice(AbstractObject $objec
       t("This object is <strong>locked by <a href=\"!user_url\">@user_name</a></strong>, so it cannot be managed. You may <strong><a href=\"!request_unlock_url\">request that they unlock the object</a></strong>.",
         array(
           '!user_url' => url("user/{$locked_by->uid}"),
-          '@user_name' => realname_load($locked_by),
+          '@user_name' => $name,
           '!request_unlock_url' => url("islandora/object/{$object->id}/request_unlock"),
         )
       ),


### PR DESCRIPTION
This PR will change all the cases where `drupal_set_message` is used to tell a user about a lock to use the same consistent message.
